### PR TITLE
Fix getNRunningThreads()

### DIFF
--- a/Engine/AppManager.cpp
+++ b/Engine/AppManager.cpp
@@ -1861,7 +1861,7 @@ AppManager::fetchAndAddNRunningThreads(int nThreads)
 int
 AppManager::getNRunningThreads() const
 {
-    return (int)_imp->runningThreadsCount;
+    return _imp->runningThreadsCount.load();
 }
 
 void


### PR DESCRIPTION
Whenever I try to compile this program on a local machine, I get and invalid cast error on line 1864. As such, I have changed it from a C-style cast to the load() function built into QAtomicInt.

Thanks in advance!
