### PR TITLE
Fix Cache::swap()

### DIFF
--- a/Engine/CacheEntry.h
+++ b/Engine/CacheEntry.h
@@ -213,7 +213,7 @@ public:
                 memcpy(dst,src,other._backingFile->size());
             }
         } else if (_storageMode == eStorageModeDisk) {
-            if (_storageMode == eStorageModeDisk) {
+            if (other._storageMode == eStorageModeDisk) {
                 assert(_backingFile);
                 _backingFile.swap(other._backingFile);
                 _path = other._path;


### PR DESCRIPTION
Fix incorrect buffer swap when "_storageMode == eStorageModeDisk" 
and "other._storageMode != eStorageModeDisk"