### PR TITLE
Updated INSTALL INSTRUCTIONS

### DIFF
--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -4,16 +4,32 @@ Developer installation for GNU/Linux
 This file is supposed to guide you step by step to have working (compiling) version of
 Natron on GNU/Linux.
 
-Note that that installing dependencies using `apt-get` should work on
-any Debian-based distribution (e.g. Ubuntu).
+1. [Libraries](#libraries)
+    - [Qt4](#qt-486)
+    - [Boost](#boost)
+    - [Expat](#expat)
+    - [Glew](#glew)
+    - [Cairo](#cairo)
+    - [Pyside](#pyside)
+    - [Shiboken](#shiboken)
+2. [Configuration](#configuration)
+    - [OpenFX](#openfx)
+    - [OpenColorIO-Configs](#download-opencolorio-configs)
+    - [config.pri](#configpri)
+    - [Nodes](#nodes)
+3. [Build](#build)
+4. [Distribution specific](#distribution-specific)
+    - [Arch Linux](#arch-linux)
+    - [Debian-based](#debian-based)
+    - [CentOS](#centos6-64-bit)
 
-The scripts `tools/travis/install_dependencies.sh` and
+
+# Libraries
+
+***note:*** *The scripts `tools/travis/install_dependencies.sh` and
 `tools/travis/build.sh` respectively install the correct dependencies
 and build Natron and the standard set of plugins on Ubuntu
-12.04. These scripts should always be up-to-date.
-
-The end of this document gives instructions for a other Linux
-distributions.
+12.04. These scripts should always be up-to-date. You can use them as a reference*
 
 ## Install libraries
 
@@ -21,67 +37,86 @@ In order to have Natron compiling, first you need to install the required librar
 
 ### Qt 4.8.6
 
-You'll need to install Qt libraries from [Qt download](http://qt-project.org/downloads).
-Alternatively you can get it from apt-get (the package depends on your distribution).
-Please download one of the version mentioned above, Natron is known to be buggy when
-running with Qt 5.
+You'll need to install Qt4 libraries, usually you can get them from your package manager (depends on your distribution).
+
+Alternatively you can download it directly from [Qt download](http://qt-project.org/downloads).
+
+Please download `Qt 4.*`, Natron is known to be buggy when running with Qt 5.
 
 
 ### Boost
 
-You can download boost from 
-[boost download](http://www.boost.org/users/download/)
-Alternatively you can install boost from apt-get. (The package depends on your distribution).
-For now just boost serialization is required.
-
-### OpenFX
-
-Go under Natron and type
-
-    git submodule update -i --recursive
+Natron requires `boost serialzation` to compile.
+You can download boost with your package manager.
+Alternatively you can install boost from [boost download](http://www.boost.org/users/download/)
 
 ### Expat
 
- (The package depends on your distribution).
+You can download it with your package manager.
+The package depends on your distribution.
 
-    sudo apt-get install expat
+
 
 ### GLEW
 
- (The package depends on your distribution).
+You can download it with your package manager.
+The package depends on your distribution.
 
-    sudo apt-get install libglew-dev
-	
-### Cairo 1.12
+### Cairo
 
-(The package depends on your distribution).
-On Ubuntu 12.04 LTS the package can be added with the following ppa:
+Natron links statically to cairo. Sometimes you can find a static version in development packages.
+If your distribution does not provide a static cairo package you will need to build it from source.
 
-    sudo add-apt-repository -y ppa:xorg-edgers/ppa 
-    sudo apt-get install libcairo2-dev
-	
+```
+git clone git://anongit.freedesktop.org/git/cairo
+cd cairo
+./autogen.sh
+make
+sudo make install
+```
 
-We're done here for libraries.
+### Pyside
 
-###Download OpenColorIO-Configs
+Natron uses pyside for python 2  
+
+### Shiboken
+
+Natron uses shiboken for python 2
+
+
+
+# Configuration
+
+### OpenFX
+
+Natron uses the OpenFX API, before building you should make sure it is up to date.
+
+For that, go under Natron and type
+
+```
+git submodule update -i --recursive
+```
+
+### Download OpenColorIO-Configs
 
 In the past, OCIO configs were a submodule, though due to the size of the repository, we have chosen instead
 to make a tarball release and let you download it [here](https://github.com/MrKepzie/OpenColorIO-Configs/archive/Natron-v2.0.tar.gz).
 Place it at the root of Natron repository.
 
-###Add the config.pri file
+***note:*** *If it is name something like: `OpenColorIO-Configs-Natron-v2.0` rename it to `OpenColorIO-Configs`*
 
-You have to define the locations of some required libraries.
-This is done by creating a .pri file next to the Project.pro that will tell the .pro
+### config.pri
+
+The `config.pri` is used to define the locations of the dependencies. It is probably the most
+confusing part of the build process.
+
+Create a `config.pri` file next to the `Project.pro` that will tell the .pro file
 where to find those libraries.
-The only library to put in the config.pri file on unix systems is boost.
-For all other libraries are found with PKGConfig.
-
-
-- create the config.pri file next to the Project.pro file.
 
 You can fill it with the following proposed code to point to the libraries.
- Of course you need to provide valid paths that are valid on your system.
+Of course you need to provide valid paths that are valid on your system.
+
+You can find more examples specific to distributions below.
 
 INCLUDEPATH is the path to the include files
 
@@ -96,28 +131,10 @@ LIBS is the path to the libs
     EOF
     ----- end -----
 
-Note that the last line for cairo is only if the package for cairo in your distribution
-is lower than version 1.12 (as it is on Ubuntu 12.04 LTS for example).
-If your distribution provide already better packages
-
-### Build
-
-The <srcPath> must be absolute and <buildPath> must not be a subdir of <srcPath>
-
-    mkdir <buildPath>
-    cd <buildfolder>
-    qmake -r <srcPath>/Project.pro
-    make
-
-If you want to build in DEBUG mode change the qmake call to this line:
-
-    qmake -r CONFIG+=debug <srcPath>/Project.pro
-
-Some debug options are available for developers of Natron and you can see them in the
-global.pri file. To enable an option just add CONFIG+=<option> in the qmake call.
+***note:*** *the last line for cairo is only necessary if the package for cairo in your distribution
+is lower than version 1.12 (as it is on Ubuntu 12.04 LTS for example).*
 
 ### Nodes
-
 
 Natron's nodes are contained in separate repositories. To use the default nodes, you must also build the following repositories:
 
@@ -136,20 +153,97 @@ Or in a directory named "Plugins" located in the parent directory where the bina
     Plugins/
         IO.ofx.bundle
 
-	
-### OpenColorIO configs
 
-Note that if you want Natron to find the OpenColorIO config files you will need to
-place them in the appropriate location. In the repository they are located under
-`Gui/Resources/OpenColorIO-Configs`.
-You must copy them to a directory named `../share/OpenColorIO-Configs` relative to Natron's binary.
+# Build
 
-# Installing and building on other Linux distributions
+To build, go into the Natron directory and type:
 
-## ArchLinux
+    qmake -r
+    make
 
-    pacman -S qt4 cairo glew python expat boost pixman ffmpeg opencolorio openimageio wget git cmake gcc make libxslt pkg-config
-    wget https://raw.githubusercontent.com/olear/natron-linux/master/include/misc/build-natron-on-archlinux.sh
+If everything has been installed and configured correctly, it should build without errors.
+
+If you want to build in DEBUG mode change the qmake call to this line:
+
+    qmake -r CONFIG+=debug
+
+Some debug options are available for developers of Natron and you can see them in the
+global.pri file. To enable an option just add `CONFIG+=<option>` in the qmake call.
+
+
+# Distribution specific
+
+## Arch Linux
+
+On Arch Linux you can do the following:
+```
+sudo pacman -S qt4 glew expat boost python2-pyside python2-shiboken
+```
+
+Cairo has to be build from source, because Arch Linux does not provide a static version (as far as we know). It is fairly easy to do:
+
+```
+git clone git://anongit.freedesktop.org/git/cairo
+cd cairo
+./autogen.sh
+make
+sudo make install
+```
+
+It should be installed in `/usr/local/lib`
+
+For the config.pri, use the following:
+
+```pri
+boost: LIBS += -lboost_serialization
+expat: LIBS += -lexpat
+expat: PKGCONFIG -= expat
+cairo {
+        # Building cairo from source (git clone, make, make install) is installed in /usr/local/lib
+        PKGCONFIG -= cairo
+        LIBS -=  $$system(pkg-config --variable=libdir cairo)/libcairo.a
+        LIBS += /usr/local/lib/libcairo.a
+}
+pyside {
+        PKGCONFIG -= pyside
+        INCLUDEPATH += $$system(pkg-config --variable=includedir pyside-py2)
+        INCLUDEPATH += $$system(pkg-config --variable=includedir pyside-py2)/QtCore
+        INCLUDEPATH += $$system(pkg-config --variable=includedir pyside-py2)/QtGui
+        INCLUDEPATH += $$system(pkg-config --variable=includedir QtGui)
+        LIBS += -lpyside-python2.7
+}
+shiboken {
+        PKGCONFIG -= shiboken
+        INCLUDEPATH += $$system(pkg-config --variable=includedir shiboken-py2)
+        LIBS += -lshiboken-python2.7
+}
+```
+
+
+## Debian-based
+
+Installing dependencies using `apt-get` should work on
+any Debian-based distribution (e.g. Ubuntu).
+
+```
+sudo apt-get install expat
+sudo apt-get install libglew-dev
+```
+
+On Ubuntu 12.04 LTS the package can be added with the following ppa:
+```
+sudo add-apt-repository -y ppa:xorg-edgers/ppa
+sudo apt-get install libcairo2-dev
+```
+
+For the config.pri use:
+
+```
+boost: LIBS += -lboost_serialization
+expat: LIBS += -lexpat
+expat: PKGCONFIG -= expat
+cairo: PKGCONFIG -= cairo
+```
 
 ## CentOS6+ (64-bit)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features
 - 32 bits floating point linear colour processing pipeline.
 - Colorspace management handled by the OpenColorIO library.
 - Dozens of file formats supported: EXR, DPX,TIFF, JPG, PNG…thanks to OpenImageIO and FFmpeg.
-- Support for many free and open-source OpenFX plugins: 
+- Support for many free and open-source OpenFX plugins:
  * [TuttleOFX](https://sites.google.com/site/tuttleofx/)
  * [OpenFX-IO](https://github.com/MrKepzie/openfx-io) to read anything else
    than standard 8-bits images
@@ -39,7 +39,7 @@ Features
 - OpenFX: Currently almost all features of OpenFX v1.4 are supported
 
 - Intuitive user interface: Natron aims not to break habits by providing an intuitive and familiar user
-interface.  It is possible to customize and separate on any number of screens the graphical user interface. 
+interface.  It is possible to customize and separate on any number of screens the graphical user interface.
 You can re-use your layouts and share your layout files (.nl)
 
 - Performances:  Never wait for anything to be rendered, in Natron anything you do produces
@@ -71,23 +71,23 @@ with a very accurate and intuitive Curve Editor as well as a Dope Sheet to quick
 
 - Command line tool for execution of project files. The command line version is executable
  on a computer without any display. Hence it is possible to use a render farm
-  to render Natron's projects. 
-  
+  to render Natron's projects.
+
 - Rotoscoping, rotopainting and tracking support
-  
+
 - Multi-view workflow: Natron saves time by keeping all the views in the same stream. You can separate
 the views at any time with the OneView node.
 
 - Python 2 scripting integration:
     * Parameters expressions
     * User-defined parameters
-    * Nodes groups as Python scripts 
+    * Nodes groups as Python scripts
     * Script editor to control the application overall
     * User-defined python callbacks to respond to particular checkpoints of the internals of the software (change of a parameter, before rendering a frame, etc…)
     * Integration of Pyside to the GUI so that the interface is extensible with new menus and windows
 
 - Multi-plane: Natron is able to deal with multi-layered EXR files thanks to OpenImageIO. It is deeply integrated into the workflow and the user can choose
-to work with any layer (or plane) on any node. New custom layers can also be created. 
+to work with any layer (or plane) on any node. New custom layers can also be created.
 
 Requirements
 ------------
@@ -137,11 +137,12 @@ These scripts are run on virtual machines running a specific version of each ope
 
 There is some documentation, which is probably outdated, for [GNU/Linux](tools/linux/README.md), [OS X](tools/MacOSX/README.md), and [Windows](tools/WindowsREADME.md).
 
+
 Planned features
 ----------------
 
 ### Features planned for the next major version
-    
+
 - Optical Flow nodes: VectorGenerator, MotionBlur, RollingShutter, Retiming
 
 - Integration of Blender's production proven tracker in Natron to replace the existing tracker
@@ -172,7 +173,7 @@ The main development branch is called
 The master branch contains the last known stable version.
 
 Additionally each stable release supported has a branch on its own.
-For example the stable release of the v1.0. and all its bug fixes should go into that 
+For example the stable release of the v1.0. and all its bug fixes should go into that
 branch.
 At some point,  version which are no longer supported will get removed from github's branches
 and only a release tag will be available to get the source code at that point.


### PR DESCRIPTION
I have updated install instructions for Linux.

- added a table of contents with anchor links to have a better overview. 
- moved distribution specific commands to the end
- detailed the Installation process on Arch Linux

The specific installation for debian-based distros is not very detailed, I only copied the commands that were already present. I can't detail more because I have no debian-based computer at home.

Let me know if I have to change / improve some things.