### PR TITLE
Linux: RC3 server changes

### DIFF
--- a/tools/linux/common.sh
+++ b/tools/linux/common.sh
@@ -50,7 +50,7 @@ GIT_OCIO_CONFIG_TAR=https://github.com/MrKepzie/OpenColorIO-Configs/archive/Natr
 COLOR_PROFILES_VERSION=2.0.0
 
 # bump timestamp on SDK changes, important!
-CORELIBS_VERSION=20151006
+CORELIBS_VERSION=20151103
 
 # SDK
 #
@@ -143,7 +143,7 @@ LIBRAW_TAR=LibRaw-0.16.0.tar.gz
 PIX_TAR=pixman-0.32.6.tar.gz
 LCMS_TAR=lcms2-2.6.tar.gz
 MAGICK_TAR=ImageMagick-6.9.1-10.tar.gz
-#SSL_TAR=openssl-1.0.0r.tar.gz #TODO ssl support in installer
+SSL_TAR=openssl-1.0.0s.tar.gz
 JASP_TAR=jasper-1.900.1.zip
 NATRON_API_DOC=https://media.readthedocs.org/pdf/natron/workshop/natron.pdf # TODO generate own?
 LAME_TAR=lame-3.99.5.tar.gz
@@ -171,6 +171,7 @@ BZIP_TAR=bzip2-1.0.6.tar.gz
 CROCO_TAR=libcroco-0.6.8.tar.xz
 SVG_TAR=librsvg-2.40.10.tar.xz
 GDK_TAR=gdk-pixbuf-2.32.1.tar.xz
+ELF_TAR=patchelf-0.8.tar.bz2
 
 TC_GCC=4.8.5
 TC_MPC=1.0.1

--- a/tools/linux/include/scripts/build-plugins.sh
+++ b/tools/linux/include/scripts/build-plugins.sh
@@ -140,7 +140,7 @@ if [ "$BUILD_IO" = "1" ]; then
 
     git clone $GIT_IO || exit 1
     cd openfx-io || exit 1
-    git checkout ${IO_RANCH} || exit 1
+    git checkout ${IO_BRANCH} || exit 1
     git submodule update -i --recursive || exit 1
     if [ "$IO_BRANCH" = "master" ]; then
         # the snapshots are always built with the latest version of submodules

--- a/tools/linux/include/scripts/build-sdk.sh
+++ b/tools/linux/include/scripts/build-sdk.sh
@@ -80,23 +80,62 @@ if [ ! -h "$INSTALL_PATH/lib64" ]; then
     ln -sf lib lib64 || exit 1
 fi
 
+# Install ssl for installler
+if [ ! -f "$INSTALL_PATH/lib/libcrypto.a" ]; then
+    cd $TMP_PATH || exit 1
+    if [ ! -f $SRC_PATH/$SSL_TAR ]; then
+        wget $THIRD_PARTY_SRC_URL/$SSL_TAR -O $SRC_PATH/$SSL_TAR || exit 1
+    fi
+    tar xvf $SRC_PATH/$SSL_TAR || exit 1
+    cd openssl* || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./config --prefix=$INSTALL_PATH || exit 1
+    make || exit 1
+    make install || exit 1
+    cd .. && rm -rf openssl*
+fi
+
 # Install static qt4 for installer
-if [ ! -f "$INSTALL_PATH/qt4-static/bin/qmake" ]; then
+if [ ! -f "$INSTALL_PATH/installer/bin/qmake" ]; then
     cd "$TMP_PATH" || exit 1
-    QTIFW_CONF="-no-multimedia -no-gif -qt-libpng -no-opengl -no-libmng -no-libtiff -no-libjpeg -static -no-openssl -confirm-license -release -opensource -nomake demos -nomake docs -nomake examples -no-gtkstyle -no-webkit -no-avx -I${INSTALL_PATH}/include -L${INSTALL_PATH}/lib"
+    QTIFW_CONF="-no-multimedia -no-gif -qt-libpng -no-opengl -no-libmng -no-libtiff -no-libjpeg -static -openssl-linked -confirm-license -release -opensource -nomake demos -nomake docs -nomake examples -no-gtkstyle -no-webkit -no-avx -I${INSTALL_PATH}/include -L${INSTALL_PATH}/lib"
 
     if [ ! -f "$SRC_PATH/$QT4_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$QT4_TAR" -O "$SRC_PATH/$QT4_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$QT4_TAR" || exit 1
     cd qt*4.8* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure -prefix $INSTALL_PATH/qt4-static $QTIFW_CONF || exit 1
+    ./configure -prefix $INSTALL_PATH/installer $QTIFW_CONF -v || exit 1
 
     # https://bugreports.qt-project.org/browse/QTBUG-5385
     env LD_LIBRARY_PATH="$LD_LIBRARY_PATH":`pwd`/lib make -j${MKJOBS} || exit 1
     make install || exit 1
     cd .. || exit 1
     rm -rf qt*4.8*
+fi
+
+# Install setup tools
+if [ ! -f $INSTALL_PATH/installer/bin/binarycreator ]; then
+    cd $TMP_PATH || exit 1
+    git clone $GIT_INSTALLER || exit 1
+    cd qtifw || exit 1
+    git checkout natron || exit 1
+    $INSTALL_PATH/installer/bin/qmake || exit 1
+    make -j${MKJOBS} || exit 1
+    strip -s bin/*
+    cp bin/* $INSTALL_PATH/installer/bin/ || exit 1
+fi
+
+# install patchelf
+if [ ! -f "$INSTALL_PATH/bin/patchelf" ]; then
+  cd "$TMP_PATH" || exit 1
+  if [ ! -f "$SRC_PATH/$ELF_TAR" ]; then
+    wget "$THIRD_PARTY_SRC_URL/$ELF_TAR" -O "$SRC_PATH/$ELF_TAR" || exit 1
+  fi
+  tar xvf $SRC_PATH/$ELF_TAR || exit 1
+  cd patchelf* || exit 1
+  ./configure || exit 1
+  make || exit 1
+  cp src/patchelf "$INSTALL_PATH/bin/" || exit 1
 fi
 
 # Install gcc
@@ -139,7 +178,7 @@ if [ ! -f "$INSTALL_PATH/gcc/bin/gcc" ]; then
 fi
 
 export LD_LIBRARY_PATH="$INSTALL_PATH/lib"
-export PATH="$INSTALL_PATH/gcc/bin:$INSTALL_PATH/bin:$PATH"
+export PATH="$INSTALL_PATH/gcc/bin:$INSTALL_PATH/bin:$INSTALL_PATH/cmake/bin:$PATH"
 
 if [ "$ARCH" = "x86_64" ]; then
     LD_LIBRARY_PATH="$INSTALL_PATH/gcc/lib64:$LD_LIBRARY_PATH"
@@ -159,10 +198,11 @@ if [ ! -f "$INSTALL_PATH/lib/libz.so.1" ]; then
     env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
+    #rm -f $INSTALL_PATH/lib/libz.so*
 fi
 
 # Install bzip
-if [ ! -f "$INSTALL_PATH/lib/libbz2.so" ]; then
+if [ ! -f "$INSTALL_PATH/lib/libbz2.so.1" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$BZIP_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$BZIP_TAR" -O "$SRC_PATH/$BZIP_TAR" || exit 1
@@ -170,13 +210,26 @@ if [ ! -f "$INSTALL_PATH/lib/libbz2.so" ]; then
     tar xvf "$SRC_PATH/$BZIP_TAR" || exit 1
     cd bzip* || exit 1
     sed -e 's/^CFLAGS=\(.*\)$/CFLAGS=\1 \$(BIGFILES)/' -i ./Makefile-libbz2_so || exit 1
+    sed -i "s/libbz2.so.1.0 -o libbz2.so.1.0.6/libbz2.so.1 -o libbz2.so.1.0.6/;s/rm -f libbz2.so.1.0/rm -f libbz2.so.1/;s/ln -s libbz2.so.1.0.6 libbz2.so.1.0/ln -s libbz2.so.1.0.6 libbz2.so.1/" Makefile-libbz2_so || exit 1
     make -f Makefile-libbz2_so || exit 1
     install -m755 libbz2.so.1.0.6 $INSTALL_PATH/lib || exit 1
     install -m644 bzlib.h $INSTALL_PATH/include/ || exit 1
     cd $INSTALL_PATH/lib || exit 1
     ln -s libbz2.so.1.0.6 libbz2.so || exit 1
     ln -s libbz2.so.1.0.6 libbz2.so.1 || exit 1
-    ln -s libbz2.so.1.0.6 libbz2.so.1.0 || exit 1
+fi
+
+# Install ssl
+if [ ! -f "$INSTALL_PATH/lib/libcrypto.so" ]; then
+    cd $TMP_PATH || exit 1
+    if [ ! -f $SRC_PATH/$SSL_TAR ]; then
+        wget $THIRD_PARTY_SRC_URL/$SSL_TAR -O $SRC_PATH/$SSL_TAR || exit 1
+    fi
+    tar xvf $SRC_PATH/$SSL_TAR || exit 1
+    cd openssl* || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./config --prefix=$INSTALL_PATH -shared || exit 1
+    make || exit 1
+    make install || exit 1
 fi
 
 # Install yasm
@@ -193,27 +246,27 @@ if [ ! -f "$INSTALL_PATH/bin/yasm" ]; then
 fi
 
 # Install cmake
-if [ ! -f "$INSTALL_PATH/bin/cmake" ]; then
+if [ ! -f "$INSTALL_PATH/cmake/bin/cmake" ]; then
     cd $TMP_PATH || exit 1
     if [ ! -f "$SRC_PATH/$CMAKE_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$CMAKE_TAR" -O "$SRC_PATH/$CMAKE_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$CMAKE_TAR" || exit 1
     cd cmake* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH/cmake" || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
 
 # Install icu
-if [ ! -f "$INSTALL_PATH/bin/icu-config" ]; then
+if [ ! -f "$INSTALL_PATH/lib/pkgconfig/icu-i18n.pc" ]; then
     cd $TMP_PATH || exit 1
     if [ ! -f "$SRC_PATH/$ICU_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$ICU_TAR" -O "$SRC_PATH/$ICU_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$ICU_TAR" || exit 1
     cd icu/source || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -226,26 +279,22 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/python2.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$PY2_TAR" || exit 1
     cd Python-2* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --enable-shared  || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix="$INSTALL_PATH" --enable-shared  || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p "$INSTALL_PATH/docs/python2" || exit 1
-    cp LICENSE "$INSTALL_PATH/docs/python2/" || exit 1
 fi
 
 # Install Python3
-if [ ! -f "$INSTALL_PATH/lib/pkgconfig/python3.pc" ]; then
+if [ ! -f "$INSTALL_PATH/lib/pkgconfig/python3.pc" ] && [ "$PYV" = "3" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$PY3_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$PY3_TAR" -O "$SRC_PATH/$PY3_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$PY3_TAR" || exit 1
     cd Python-3* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix=$INSTALL_PATH --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p "$INSTALL_PATH/docs/python3" || exit 1
-    cp LICENSE "$INSTALL_PATH/docs/python3/" || exit 1
 fi
 
 # Setup env
@@ -260,14 +309,14 @@ PYTHON_INCLUDE="$INSTALL_PATH/include/python2.7"
 export PKG_CONFIG_PATH LD_LIBRARY_PATH PATH QTDIR BOOST_ROOT OPENJPEG_HOME THIRD_PARTY_TOOLS_HOME PYTHON_HOME PYTHON_PATH PYTHON_INCLUDE
 
 # Install expat
-if [ ! -f "$INSTALL_PATH/lib/libexpat.so" ]; then
+if [ ! -f "$INSTALL_PATH/lib/pkgconfig/expat.pc" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$EXPAT_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$EXPAT_TAR" -O "$SRC_PATH/$EXPAT_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$EXPAT_TAR" || exit 1
     cd expat* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -280,35 +329,33 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/libpng.pc ]; then
     fi
     tar xvf $SRC_PATH/$PNG_TAR || exit 1
     cd libpng* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/png || exit 1
-    cp LIC* COP* README AUTH* CONT* $INSTALL_PATH/docs/png/
 fi
 
 # Install freetype
-if [ ! -f "$INSTALL_PATH/lib/libfreetype.so" ]; then
+if [ ! -f "$INSTALL_PATH/lib/pkgconfig/freetype2.pc" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$FTYPE_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$FTYPE_TAR" -O "$SRC_PATH/$FTYPE_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$FTYPE_TAR" || exit 1
     cd freetype* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
 
 # Install fontconfig
-if [ ! -f "$INSTALL_PATH/lib/libfontconfig.so" ]; then
+if [ ! -f "$INSTALL_PATH/lib/pkgconfig/fontconfig.pc" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$FCONFIG_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$FCONFIG_TAR" -O "$SRC_PATH/$FCONFIG_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$FCONFIG_TAR" || exit 1
     cd fontconfig* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -321,7 +368,7 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/libffi.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$FFI_TAR" || exit 1
     cd libffi* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -334,7 +381,7 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/glib-2.0.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$GLIB_TAR" || exit 1
     cd glib-2* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -347,20 +394,20 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/libxml-2.0.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$LIBXML_TAR" || exit 1
     cd libxml* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared --without-python || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared --without-python || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
 
 # Install xslt
-if [ ! -f "$INSTALL_PATH/lib/libxslt.so.1" ]; then
+if [ ! -f "$INSTALL_PATH/lib/pkgconfig/libxslt.pc" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$LIBXSLT_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$LIBXSLT_TAR" -O "$SRC_PATH/$LIBXSLT_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$LIBXSLT_TAR" || exit 1
     cd libxslt* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared --without-python || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared --without-python || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -373,26 +420,21 @@ if [ ! -f "$INSTALL_PATH/lib/libboost_atomic.so" ]; then
     fi
     tar xvf "$SRC_PATH/$BOOST_TAR" || exit 1
     cd boost_* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./bootstrap.sh || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./b2 -j${MKJOBS} --disable-icu || exit 1
-    ./b2 install --prefix=$INSTALL_PATH || exit 1
-    mkdir -p $INSTALL_PATH/docs/boost || exit 1
-    cp LICENSE_1_0.txt $INSTALL_PATH/docs/boost/ || exit 1
+    ./bootstrap.sh || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./b2 --prefix=$INSTALL_PATH cflags="-fPIC" --disable-icu -j${MKJOBS} install || exit 1 # link=static
 fi
 
 # Install jpeg
-if [ ! -f $INSTALL_PATH/lib/libjpeg.a ]; then
+if [ ! -f $INSTALL_PATH/lib/libjpeg.so ]; then
     cd $TMP_PATH || exit 1
     if [ ! -f $SRC_PATH/$JPG_TAR ]; then
         wget $THIRD_PARTY_SRC_URL/$JPG_TAR -O $SRC_PATH/$JPG_TAR || exit 1
     fi
     tar xvf $SRC_PATH/$JPG_TAR || exit 1
     cd jpeg-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/jpeg || exit 1
-    cp LIC* COP* READ* AUTH* CONT* $INSTALL_PATH/docs/jpeg/
 fi
 
 # Install tiff
@@ -403,26 +445,22 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/libtiff-4.pc ]; then
     fi
     tar xvf $SRC_PATH/$TIF_TAR || exit 1
     cd tiff-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/tiff || exit 1
-    cp LIC* COP* README AUTH* CONT* $INSTALL_PATH/docs/tiff/
 fi
 
 # Install jasper
-if [ ! -f $INSTALL_PATH/lib/libjasper.a ]; then
+if [ ! -f $INSTALL_PATH/lib/libjasper.so ]; then
     cd $TMP_PATH || exit 1
     if [ ! -f $SRC_PATH/$JASP_TAR ]; then
         wget $THIRD_PARTY_SRC_URL/$JASP_TAR -O $SRC_PATH/$JASP_TAR || exit 1
     fi
     unzip $SRC_PATH/$JASP_TAR || exit 1
     cd jasper* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/jasper || exit 1
-    cp LIC* COP* Copy* README AUTH* CONT* $INSTALL_PATH/docs/jasper/
 fi
 
 # Install lcms
@@ -433,11 +471,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/lcms2.pc ]; then
     fi
     tar xvf $SRC_PATH/$LCMS_TAR || exit 1
     cd lcms2-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --disable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/lcms || exit 1
-    cp LIC* COP* README AUTH* CONT* $INSTALL_PATH/docs/lcms/
 fi
 
 # Install openjpeg
@@ -449,11 +485,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/libopenjpeg.pc ]; then
     tar xvf $SRC_PATH/$OJPG_TAR || exit 1
     cd openjpeg-* || exit 1
     ./bootstrap.sh || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --disable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/openjpeg || exit 1
-    cp LIC* COP* READ* AUTH* CONT* $INSTALL_PATH/docs/openjpeg/
 fi
 
 # Install libraw
@@ -464,12 +498,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/libraw.pc ]; then
     fi
     tar xvf $SRC_PATH/$LIBRAW_TAR || exit 1
     cd LibRaw* || exit 1
-    mkdir build && cd build
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_BUILD_TYPE=Release || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install
-    mkdir -p $INSTALL_PATH/docs/libraw || exit 1
-    cp ../README ../COPYRIGHT ../LIC* $INSTALL_PATH/docs/libraw/ || exit 1
 fi
 
 # Install openexr
@@ -480,11 +511,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/OpenEXR.pc ]; then
     fi
     tar xvf $SRC_PATH/$ILM_TAR || exit 1
     cd ilmbase-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/openexr || exit 1
-    cp LIC* COP* README AUTH* CONT* $INSTALL_PATH/docs/openexr/
 
     cd $TMP_PATH || exit 1
     if [ ! -f $SRC_PATH/$EXR_TAR ]; then
@@ -492,10 +521,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/OpenEXR.pc ]; then
     fi
     tar xvf $SRC_PATH/$EXR_TAR || exit 1
     cd openexr-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    cp LIC* COP* README AUTH* CONT* $INSTALL_PATH/docs/openexr/
 fi
 
 # Install pixman
@@ -505,11 +533,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/pixman-1.pc ]; then
     fi
     tar xvf $SRC_PATH/$PIX_TAR || exit 1
     cd pixman-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --disable-shared --enable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/pixman || exit 1
-    cp COPYING* README AUTHORS $INSTALL_PATH/docs/pixman/ || exit 1
 fi
 
 # Install cairo
@@ -523,8 +549,6 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/cairo.pc ]; then
     env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include -I${INSTALL_PATH}/include/pixman-1" LDFLAGS="-L${INSTALL_PATH}/lib -lpixman-1" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/cairo || exit 1
-    cp COPYING* README AUTHORS $INSTALL_PATH/docs/cairo/ || exit 1
 fi
 
 # Install harbuzz
@@ -535,19 +559,7 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/harfbuzz.pc ]; then
     fi
     tar xvf $SRC_PATH/$BUZZ_TAR || exit 1
     cd harfbuzz-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --disable-docs --enable-static --enable-shared --with-freetype --with-cairo --with-gobject --with-glib --with-icu || exit 1
-    make -j${MKJOBS} || exit 1
-    make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/cairo || exit 1
-    cp COPYING* README AUTHORS $INSTALL_PATH/docs/cairo/ || exit 1
-    cd "$TMP_PATH" || exit 1
-    if [ ! -f "$SRC_PATH/$FTYPE_TAR" ]; then
-        wget "$THIRD_PARTY_SRC_URL/$FTYPE_TAR" -O "$SRC_PATH/$FTYPE_TAR" || exit 1
-    fi
-    rm -rf freetype*
-    tar xvf "$SRC_PATH/$FTYPE_TAR" || exit 1
-    cd freetype* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --disable-docs --disable-static --enable-shared --with-freetype --with-cairo --with-gobject --with-glib --without-icu || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -560,20 +572,20 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/pango.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$PANGO_TAR" || exit 1
     cd pango-* || exit 1
-    env FONTCONFIG_CFLAGS="-I$INSTALL_PATH/include" FONTCONFIG_LIBS="-L$INSTALL_PATH/lib -lfontconfig" CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared --with-included-modules=basic-fc || exit 1
+    env FONTCONFIG_CFLAGS="-I$INSTALL_PATH/include" FONTCONFIG_LIBS="-L$INSTALL_PATH/lib -lfontconfig" CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared --with-included-modules=basic-fc || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
 
 # Install croco
-if [ ! -f "$INSTALL_PATH/lib/libcroco-0.6.so.3" ]; then
+if [ ! -f "$INSTALL_PATH/lib/libcroco-0.6.so" ]; then
     cd "$TMP_PATH" || exit 1
     if [ ! -f "$SRC_PATH/$CROCO_TAR" ]; then
         wget "$THIRD_PARTY_SRC_URL/$CROCO_TAR" -O "$SRC_PATH/$CROCO_TAR" || exit 1
     fi
     tar xvf "$SRC_PATH/$CROCO_TAR" || exit 1
     cd libcroco-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -586,7 +598,7 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/gdk-pixbuf-2.0.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$GDK_TAR" || exit 1
     cd gdk-pix* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared --without-libtiff || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -599,7 +611,7 @@ if [ ! -f "$INSTALL_PATH/lib/pkgconfig/librsvg-2.0.pc" ]; then
     fi
     tar xvf "$SRC_PATH/$SVG_TAR" || exit 1
     cd librsvg-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --enable-static --enable-shared --disable-introspection --disable-vala --disable-pixbuf-loader || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$INSTALL_PATH" --disable-docs --disable-static --enable-shared --disable-introspection --disable-vala --disable-pixbuf-loader || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
 fi
@@ -616,11 +628,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/Magick++.pc ]; then
     tar xvf $SRC_PATH/$MAGICK_TAR || exit 1
     cd ImageMagick-* || exit 1
     patch -p0 < $INC_PATH/patches/ImageMagick/pango-align-hack.diff || exit 1
-    env CFLAGS="$BF -DMAGICKCORE_EXCLUDE_DEPRECATED=1" CXXFLAGS="$BF -DMAGICKCORE_EXCLUDE_DEPRECATED=1" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --with-magick-plus-plus=yes --with-quantum-depth=32 --without-dps --without-djvu --without-fftw --without-fpx --without-gslib --without-gvc --without-jbig --without-jpeg --with-lcms --without-openjp2 --without-lqr --without-lzma --without-openexr --with-pango --with-png --with-rsvg --without-tiff --without-webp --with-xml --without-zlib --without-bzlib --enable-static --disable-shared --enable-hdri --with-freetype --with-fontconfig --without-x --without-modules || exit 1
+    env CFLAGS="$BF -DMAGICKCORE_EXCLUDE_DEPRECATED=1" CXXFLAGS="$BF -DMAGICKCORE_EXCLUDE_DEPRECATED=1" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --with-magick-plus-plus=yes --with-quantum-depth=32 --without-dps --without-djvu --without-fftw --without-fpx --without-gslib --without-gvc --without-jbig --without-jpeg --with-lcms --without-openjp2 --without-lqr --without-lzma --without-openexr --with-pango --with-png --with-rsvg --without-tiff --without-webp --with-xml --without-zlib --without-bzlib --disable-static --enable-shared --enable-hdri --with-freetype --with-fontconfig --without-x --without-modules || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/imagemagick || exit 1
-    cp LIC* COP* Copy* Lic* README AUTH* CONT* $INSTALL_PATH/docs/imagemagick/
 fi
 
 # Install glew
@@ -638,6 +648,7 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/glew.pc ]; then
     fi
     make install GLEW_DEST=$INSTALL_PATH libdir=/lib bindir=/bin includedir=/include || exit 1
     mkdir -p $INSTALL_PATH/docs/glew || exit 1
+    #rm -f $INSTALL_PATH/lib/*GLEW*.so*
     cp LICENSE.txt README.txt $INSTALL_PATH/docs/glew/ || exit 1
 fi
 
@@ -651,13 +662,11 @@ if [ ! -f $INSTALL_PATH/lib/libOpenColorIO.so ]; then
     cd OpenColorIO-* || exit 1
     mkdir build || exit 1
     cd build || exit 1
-    #env CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_JNIGLUE=OFF -DOCIO_BUILD_NUKE=OFF -DOCIO_BUILD_SHARED=ON -DOCIO_BUILD_STATIC=OFF -DOCIO_STATIC_JNIGLUE=OFF -DUSE_EXTERNAL_LCMS=ON -DOCIO_BUILD_TRUELIGHT=OFF -DUSE_EXTERNAL_TINYXML=OFF -DUSE_EXTERNAL_YAML=OFF -DOCIO_BUILD_APPS=OFF -DOCIO_USE_BOOST_PTR=ON -DOCIO_BUILD_TESTS=OFF -DOCIO_BUILD_PYGLUE=OFF
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_SHARED=ON -DOCIO_BUILD_STATIC=OFF || exit 1
-    # dont work, wtf! #-DUSE_EXTERNAL_LCMS=ON || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_SHARED=ON -DOCIO_BUILD_STATIC=OFF -DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_PYGLUE=OFF || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/ocio || exit 1
-    cp ../LICENSE ../README $INSTALL_PATH/docs/ocio/ || exit 1
+    cp ext/dist/lib/{liby*.a,libt*.a} $INSTALL_PATH/lib/ || exit 1
+    sed -i "s/-lOpenColorIO/-lOpenColorIO -lyaml-cpp -ltinyxml -llcms2/" $INSTALL_PATH/lib/pkgconfig/OpenColorIO.pc || exit 1
 fi
 
 # Install oiio
@@ -674,48 +683,61 @@ if [ ! -f $INSTALL_PATH/lib/libOpenImageIO.so ]; then
     patch -p1 -i $INC_PATH/patches/OpenImageIO/pre-1.5.21.patch || exit 1
     mkdir build || exit 1
     cd build || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" CXXFLAGS="-fPIC" cmake -DUSE_OPENCV:BOOL=FALSE -DUSE_OPENSSL:BOOL=FALSE -DOPENEXR_HOME=$INSTALL_PATH -DILMBASE_HOME=$INSTALL_PATH -DTHIRD_PARTY_TOOLS_HOME=$INSTALL_PATH -DUSE_QT:BOOL=FALSE -DUSE_TBB:BOOL=FALSE -DUSE_PYTHON:BOOL=FALSE -DUSE_FIELD3D:BOOL=FALSE -DUSE_OPENJPEG:BOOL=FALSE  -DOIIO_BUILD_TESTS=0 -DOIIO_BUILD_TOOLS=0 -DUSE_LIB_RAW=1 -DLIBRAW_PATH=$INSTALL_PATH -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DBOOST_ROOT=$INSTALL_PATH -DSTOP_ON_WARNING:BOOL=FALSE -DUSE_GIF:BOOL=TRUE -DUSE_FREETYPE:BOOL=TRUE -DFREETYPE_INCLUDE_PATH=$INSTALL_PATH/include -DUSE_FFMPEG:BOOL=FALSE .. || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" CXXFLAGS="-fPIC" cmake -DUSE_OPENCV:BOOL=FALSE -DUSE_OPENSSL:BOOL=FALSE -DOPENEXR_HOME=$INSTALL_PATH -DILMBASE_HOME=$INSTALL_PATH -DTHIRD_PARTY_TOOLS_HOME=$INSTALL_PATH -DUSE_QT:BOOL=FALSE -DUSE_TBB:BOOL=FALSE -DUSE_PYTHON:BOOL=FALSE -DUSE_FIELD3D:BOOL=FALSE -DUSE_OPENJPEG:BOOL=FALSE  -DOIIO_BUILD_TESTS=0 -DOIIO_BUILD_TOOLS=0 -DUSE_LIB_RAW=1 -DLIBRAW_PATH=$INSTALL_PATH -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DBOOST_ROOT=$INSTALL_PATH -DSTOP_ON_WARNING:BOOL=FALSE -DUSE_GIF:BOOL=TRUE -DUSE_FREETYPE:BOOL=TRUE -DFREETYPE_INCLUDE_PATH=$INSTALL_PATH/include -DUSE_FFMPEG:BOOL=FALSE -DLINKSTATIC=0 -DBUILDSTATIC=0 .. || exit 1 
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/oiio || exit 1
-    cp ../LICENSE ../README* ../CREDITS $INSTALL_PATH/docs/oiio || exit 1
+fi
+
+# Install SeExpr
+if [ ! -f $INSTALL_PATH/lib/libSeExpr.so ]; then
+    cd $TMP_PATH || exit 1
+    if [ ! -f $SRC_PATH/$SEE_TAR ]; then
+        wget $THIRD_PARTY_SRC_URL/$SEE_TAR -O $SRC_PATH/$SEE_TAR || exit 1
+    fi
+    tar xvf $SRC_PATH/$SEE_TAR || exit 1
+    cd SeExpr-* || exit 1
+    mkdir build || exit 1
+    cd build || exit 1
+    CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH || exit 1
+    make || exit 1
+    make install || exit 1
+    #rm -f $INSTALL_PATH/lib/libSeExpr.so
 fi
 
 # Install eigen
-if [ ! -f $INSTALL_PATH/lib/pkgconfig/eigen3.pc ]; then
-    cd $TMP_PATH || exit 1
-    if [ ! -f $CWD/src/$EIGEN_TAR ]; then
-        wget $THIRD_PARTY_SRC_URL/$EIGEN_TAR -O $CWD/src/$EIGEN_TAR || exit 1
-    fi
-    tar xvf $CWD/src/$EIGEN_TAR || exit 1
-    cd eigen-* || exit 1
-    rm -rf build
-    mkdir build || exit 1
-    cd build || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH || exit 1
-    make -j${MKJOBS} || exit 1
-    make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/eigen || exit 1
-    cp ../LIC* ../COP* ../README ../AUTH* ../CONT* $INSTALL_PATH/docs/eigen/
-    mv $INSTALL_PATH/share/pkgconfig/* $INSTALL_PATH/lib/pkgconfig
-fi
+#if [ ! -f $INSTALL_PATH/lib/pkgconfig/eigen3.pc ]; then
+#    cd $TMP_PATH || exit 1
+#    if [ ! -f $CWD/src/$EIGEN_TAR ]; then
+#        wget $THIRD_PARTY_SRC_URL/$EIGEN_TAR -O $CWD/src/$EIGEN_TAR || exit 1
+#    fi
+#    tar xvf $CWD/src/$EIGEN_TAR || exit 1
+#    cd eigen-* || exit 1
+#    rm -rf build
+#    mkdir build || exit 1
+#    cd build || exit 1
+#    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH || exit 1
+#    make -j${MKJOBS} || exit 1
+#    make install || exit 1
+#    mv $INSTALL_PATH/share/pkgconfig/* $INSTALL_PATH/lib/pkgconfig
+#fi
 
 # Install opencv
-if [ ! -f $INSTALL_PATH/lib/pkgconfig/opencv.pc ]; then
-    cd $TMP_PATH || exit 1
-    if [ ! -f $CWD/src/$CV_TAR ]; then
-        wget $THIRD_PARTY_SRC_URL/$CV_TAR -O $CWD/src/$CV_TAR || exit 1
-    fi
-    unzip $CWD/src/$CV_TAR || exit 1
-    cd opencv* || exit 1
-    mkdir build || exit 1
-    cd build || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CMAKE_INCLUDE_PATH=$INSTALL_PATH/include CMAKE_LIBRARY_PATH=$INSTALL_PATH/lib CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake -DWITH_GTK=OFF -DWITH_GSTREAMER=OFF -DWITH_FFMPEG=OFF -DWITH_OPENEXR=OFF -DWITH_OPENCL=OFF -DWITH_OPENGL=ON -DBUILD_WITH_DEBUG_INFO=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_SSE3=OFF .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH || exit 1
-    make -j${MKJOBS} || exit 1
-    make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/opencv || exit 1
-    cp ../LIC* ../COP* ../README ../AUTH* ../CONT* $INSTALL_PATH/docs/opencv/
-fi
+#if [ ! -f $INSTALL_PATH/lib/pkgconfig/opencv.pc ]; then
+#    cd $TMP_PATH || exit 1
+#    if [ ! -f $CWD/src/$CV_TAR ]; then
+#        wget $THIRD_PARTY_SRC_URL/$CV_TAR -O $CWD/src/$CV_TAR || exit 1
+#    fi
+#    unzip $CWD/src/$CV_TAR || exit 1
+#    cd opencv* || exit 1
+#    mkdir build || exit 1
+#    cd build || exit 1
+#    env CFLAGS="$BF" CXXFLAGS="$BF" CMAKE_INCLUDE_PATH=$INSTALL_PATH/include CMAKE_LIBRARY_PATH=$INSTALL_PATH/lib CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake -DWITH_GTK=OFF -DWITH_GSTREAMER=OFF -DWITH_FFMPEG=OFF -DWITH_OPENEXR=OFF -DWITH_OPENCL=OFF -DWITH_OPENGL=ON -DBUILD_WITH_DEBUG_INFO=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_SSE3=OFF .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH || exit 1
+#    make -j${MKJOBS} || exit 1
+#    make install || exit 1
+#    mkdir -p $INSTALL_PATH/docs/opencv || exit 1
+#    cp ../LIC* ../COP* ../README ../AUTH* ../CONT* $INSTALL_PATH/docs/opencv/
+#fi
+
 
 # Install lame
 if [ ! -f $INSTALL_PATH/lib/libmp3lame.so ]; then
@@ -725,11 +747,9 @@ if [ ! -f $INSTALL_PATH/lib/libmp3lame.so ]; then
     fi
     tar xvf $SRC_PATH/$LAME_TAR || exit 1
     cd lame-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/lame || exit 1
-    cp COPY* $INSTALL_PATH/docs/lame/
 fi
 
 # Install ogg
@@ -740,11 +760,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/ogg.pc ]; then
     fi
     tar xvf $SRC_PATH/$OGG_TAR || exit 1
     cd libogg-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/libogg || exit 1
-    cp COPY* $INSTALL_PATH/docs/libogg/
 fi
 
 # Install vorbis
@@ -755,11 +773,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/vorbis.pc ]; then
     fi
     tar xvf $SRC_PATH/$VORBIS_TAR || exit 1
     cd libvorbis-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --disable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/libvorbis || exit 1
-    cp COPY* $INSTALL_PATH/docs/libvorbis/
 fi
 
 # Install theora
@@ -773,8 +789,6 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/theora.pc ]; then
     env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/libtheora || exit 1
-    cp COPY* $INSTALL_PATH/docs/libtheora/
 fi
 
 # Install modplug
@@ -788,8 +802,6 @@ if [ ! -f $INSTALL_PATH/lib/libmodplug.so ]; then
     env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/libmodplug || exit 1
-    cp COPY* $INSTALL_PATH/docs/libmodplug/
 fi
 
 # Install vpx
@@ -800,11 +812,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/vpx.pc ]; then
     fi
     tar xvf $SRC_PATH/$VPX_TAR || exit 1
     cd libvpx-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static --enable-vp8 --enable-vp9 --enable-runtime-cpu-detect --enable-postproc --enable-pic --disable-avx --disable-avx2 --disable-examples || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static --enable-vp8 --enable-vp9 --enable-runtime-cpu-detect --enable-postproc --enable-pic --disable-avx --disable-avx2 --disable-examples || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/libvpx || exit 1
-    cp LIC* $INSTALL_PATH/docs/libvpx/
 fi
 
 # Install speex
@@ -815,11 +825,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/speex.pc ]; then
     fi
     tar xvf $SRC_PATH/$SPEEX_TAR || exit 1
     cd speex-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/speex || exit 1
-    cp COPY* $INSTALL_PATH/docs/speex/
 fi
 
 # Install opus
@@ -830,11 +838,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/opus.pc ]; then
     fi
     tar xvf $SRC_PATH/$OPUS_TAR || exit 1
     cd opus-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static --enable-custom-modes || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static --enable-custom-modes || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/opus || exit 1
-    cp COP* $INSTALL_PATH/docs/opus/
 fi
 
 # Install orc
@@ -845,11 +851,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/orc-0.4.pc ]; then
     fi
     tar xvf $SRC_PATH/$ORC_TAR || exit 1
     cd orc-* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/orc || exit 1
-    cp COP* $INSTALL_PATH/docs/orc/
 fi
 
 # Install dirac
@@ -860,14 +864,14 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/schroedinger-1.0.pc ]; then
     fi
     tar xvf $SRC_PATH/$DIRAC_TAR || exit 1
     cd schro* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/dirac || exit 1
-    cp COP* $INSTALL_PATH/docs/dirac/
+    #rm -f $INSTALL_PATH/lib/libschro*.so*
+    sed -i "s/-lschroedinger-1.0/-lschroedinger-1.0 -lorc-0.4/" $INSTALL_PATH/lib/pkgconfig/schroedinger-1.0.pc || exit 1
 fi
 
-# x264 (GPL)
+# x264
 if [ ! -f $INSTALL_PATH/lib/pkgconfig/x264.pc ]; then
     cd $TMP_PATH || exit 1
     if [ ! -f $SRC_PATH/$X264_TAR ]; then
@@ -875,26 +879,24 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/x264.pc ]; then
     fi
     tar xvf $SRC_PATH/$X264_TAR || exit 1
     cd x264* || exit 1
-    ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static --enable-pic --bit-depth=10  CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" || exit 1
+    ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static --enable-pic --bit-depth=10  CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/x264 || exit 1
-    cp COP* LIC* $INSTALL_PATH/docs/x264/
+    #rm -f $INSTALL_PATH/lib/libx264*.so*
 fi
 
-# xvid (GPL)
-if [ ! -f $INSTALL_PATH/lib/libxvidcore.so.4.3 ]; then
+# xvid
+if [ ! -f $INSTALL_PATH/lib/libxvidcore.a ]; then
     cd $TMP_PATH || exit 1
     if [ ! -f $SRC_PATH/$XVID_TAR ]; then
         wget $THIRD_PARTY_SRC_URL/$XVID_TAR -O $SRC_PATH/$XVID_TAR || exit 1
     fi
     tar xvf $SRC_PATH/$XVID_TAR || exit 1
     cd xvidcore/build/generic || exit 1
-    ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --disable-static CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" || exit 1
+    ./configure --prefix=$INSTALL_PATH --libdir=$INSTALL_PATH/lib --enable-shared --enable-static CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" || exit 1
     make -j${MKJOBS} || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/xvidcore || exit 1
-    cp ../../COP* ../../LIC* $INSTALL_PATH/docs/xvidcore/
+    #rm -f $INSTALL_PATH/lib/libxvidcore*.so*
 fi
 
 # Install ffmpeg
@@ -915,10 +917,8 @@ if [ ! -d $INSTALL_PATH/ffmpeg-gpl ] || [ ! -d $INSTALL_PATH/ffmpeg-lgpl ]; then
     make -j${MKJOBS} || exit 1
     make install || exit 1
     make distclean
-    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH/ffmpeg-lgpl --libdir=$INSTALL_PATH/ffmpeg-lgpl/lib --enable-shared --disable-static $LGPL_SETTINGS || exit 1
+    env CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" ./configure --prefix=$INSTALL_PATH/ffmpeg-lgpl --libdir=$INSTALL_PATH/ffmpeg-lgpl/lib --enable-shared --disable-static $LGPL_SETTINGS  || exit 1
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/ffmpeg || exit 1
-    cp COPYING* CREDITS $INSTALL_PATH/docs/ffmpeg/
 fi
 
 # Install qt
@@ -926,10 +926,10 @@ if [ ! -f $INSTALL_PATH/bin/qmake ]; then
     cd $TMP_PATH || exit 1
     if [ "$1" = "qt5" ]; then
         QT_TAR=$QT5_TAR
-        QT_CONF="-no-openssl -opengl desktop -opensource -nomake examples -nomake tests -release -no-gtkstyle -confirm-license -no-c++11 -I${INSTALL_PATH}/include -L${INSTALL_PATH}/lib"
+        QT_CONF="-openssl-linked -opengl desktop -opensource -nomake examples -nomake tests -release -no-gtkstyle -confirm-license -no-c++11 -I${INSTALL_PATH}/include -L${INSTALL_PATH}/lib"
     else
         QT_TAR=$QT4_TAR
-        QT_CONF="-xrender -xrandr -xcursor -xfixes -xinerama -fontconfig -xinput -sm -no-multimedia -no-openssl -confirm-license -release -opensource -opengl desktop -nomake demos -nomake docs -nomake examples -no-gtkstyle -I${INSTALL_PATH}/include -L${INSTALL_PATH}/lib"
+        QT_CONF="-system-zlib -system-libtiff -system-libpng -no-libmng -system-libjpeg -no-gtkstyle -glib -xrender -xrandr -xcursor -xfixes -xinerama -fontconfig -xinput -sm -no-multimedia -openssl-linked -confirm-license -release -opensource -opengl desktop -nomake demos -nomake docs -nomake examples -I${INSTALL_PATH}/include -L${INSTALL_PATH}/lib"
     fi
 
     if [ ! -f $SRC_PATH/$QT_TAR ]; then
@@ -944,8 +944,6 @@ if [ ! -f $INSTALL_PATH/bin/qmake ]; then
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH":`pwd`/lib make -j${MKJOBS} || exit  1
 
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/qt || exit 1
-    cp README LICENSE.LGPL LGPL_EXCEPTION.txt $INSTALL_PATH/docs/qt/ || exit 1
     rm -rf $TMP_PATH/qt*
 fi
 
@@ -980,11 +978,9 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/shiboken.pc ]; then
           -DPYTHON_LIBRARY=$PY_LIB \
           -DPYTHON_INCLUDE_DIR=$PY_INC \
           -DUSE_PYTHON3=$USE_PY3 \
-          -DQT_QMAKE_EXECUTABLE=$INSTALL_PATH/bin/qmake
+          -DQT_QMAKE_EXECUTABLE=$INSTALL_PATH/bin/qmake -DCMAKE_EXE_LINKER_FLAGS="-lz"
     make -j${MKJOBS} || exit 1 
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/shibroken || exit 1
-    cp ../COPY* $INSTALL_PATH/docs/shibroken/
 fi
 
 # Install pyside
@@ -1003,50 +999,6 @@ if [ ! -f $INSTALL_PATH/lib/pkgconfig/pyside.pc ]; then
           -DPYTHON_INCLUDE_DIR=$PY_INC
     make -j${MKJOBS} || exit 1 
     make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/pyside || exit 1
-    cp ../COPY* $INSTALL_PATH/docs/pyside/ || exit 1
-fi
-
-# Install SeExpr
-if [ ! -f $INSTALL_PATH/lib/libSeExpr.so ]; then
-    cd $TMP_PATH || exit 1
-    if [ ! -f $SRC_PATH/$SEE_TAR ]; then
-        wget $THIRD_PARTY_SRC_URL/$SEE_TAR -O $SRC_PATH/$SEE_TAR || exit 1
-    fi
-    tar xvf $SRC_PATH/$SEE_TAR || exit 1
-    cd SeExpr-* || exit 1
-    mkdir build || exit 1
-    cd build || exit 1
-    CFLAGS="$BF" CXXFLAGS="$BF" CPPFLAGS="-I${INSTALL_PATH}/include" LDFLAGS="-L${INSTALL_PATH}/lib" cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH || exit 1
-    make || exit 1
-    make install || exit 1
-    mkdir -p $INSTALL_PATH/docs/seexpr || exit 1
-    cp ../README ../src/doc/license.txt $INSTALL_PATH/docs/seexpr/ || exit 1
-fi
-
-# Install SSL (for installer, not working yet)
-if [ "$SSL_TAR" != "" ]; then
-    cd $TMP_PATH || exit 1
-    if [ ! -f $SRC_PATH/$SSL_TAR ]; then
-        wget $THIRD_PARTY_SRC_URL/$SSL_TAR -O $SRC_PATH/$SSL_TAR || exit 1
-    fi
-    tar xvf $SRC_PATH/$SSL_TAR || exit 1
-    cd openssl* || exit 1
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./config --prefix=$INSTALL_PATH || exit 1
-    make || exit 1
-    make install || exit 1
-fi
-
-# Install setup tools
-if [ ! -f $INSTALL_PATH/bin/binarycreator ]; then
-    cd $TMP_PATH || exit 1
-    git clone $GIT_INSTALLER || exit 1
-    cd qtifw || exit 1
-    git checkout natron || exit 1
-    $INSTALL_PATH/qt4-static/bin/qmake || exit 1
-    make -j${MKJOBS} || exit 1
-    strip -s bin/*
-    cp bin/* $INSTALL_PATH/bin/ || exit 1
 fi
 
 if [ ! -z "$TAR_SDK" ]; then
@@ -1060,7 +1012,6 @@ if [ ! -z "$TAR_SDK" ]; then
     fi
 
 fi
-
 
 echo
 echo "Natron SDK Done"


### PR DESCRIPTION
RC3 changes:
- ssl support in installer and qt
- rpath all libs
- other minor

Don't merge this before downloading the new SDK on snapshot server (or build your own):
- http://downloads.natron.fr/Third_Party_Binaries/Natron-2.0.0-RC3-CY2015-Linux-i686-SDK.tar.xz
- http://downloads.natron.fr/Third_Party_Binaries/Natron-2.0.0-RC3-CY2015-Linux-x86_64-SDK.tar.xz