### PR TITLE
Fix autosave file not being removed when discarded: #1398

### DIFF
--- a/Gui/Gui.cpp
+++ b/Gui/Gui.cpp
@@ -219,7 +219,7 @@ Gui::abortProject(bool quitApp,
             if ( !saveProject() ) {
                 return false;
             }
-        } else if (ret ==1) {
+        } else if (ret == 1) {
             getApp()->getProject()->removeLastAutosave();
         } else if (ret == 2) {
             return false;

--- a/Gui/Gui.cpp
+++ b/Gui/Gui.cpp
@@ -219,6 +219,8 @@ Gui::abortProject(bool quitApp,
             if ( !saveProject() ) {
                 return false;
             }
+        } else if (ret ==1) {
+            getApp()->getProject()->removeLastAutosave();
         } else if (ret == 2) {
             return false;
         }


### PR DESCRIPTION
Fixes an issue mentioned in #1398 where the autosave file is not deleted when changes have been discarded.

So far I have not been able to reproduce the lock file not being deleted.
