### PR TITLE
fix bug: QFont Natron::KnobGuiString::makeFontFromState() const error…

### DIFF
--- a/Gui/KnobGuiString.cpp
+++ b/Gui/KnobGuiString.cpp
@@ -420,11 +420,12 @@ KnobGuiString::KnobGuiString(const KnobGuiPtr& knob, ViewIdx view)
 QFont
 KnobGuiString::makeFontFromState() const
 {
+    QFont f; //modefy by lihaiping1603@aliyun.com
     KnobStringPtr knob = _knob.lock();
     if (!knob) {
-        return;
+        return f;
     }
-    QFont f;
+//    QFont f;
     f.setFamily(QString::fromUtf8(knob->getFontFamily().c_str()));
     f.setPointSize(knob->getFontSize());
     f.setBold(knob->getBoldActivated());


### PR DESCRIPTION
…: return-statement with no value, in function returning ‘QFont’

Please read the [contribution guidelines](https://github.com/MrKepzie/Natron/blob/master/CONTRIBUTING.md), and be sure we have a [Contributor License Agreement](http://natron.fr/cla) on record with the project.

## Description

Please provide a description of what this PR is meant to fix,
and how it works (if it's not going to be very clear from the code).
